### PR TITLE
Don't use pregenerated files anymore

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -8,8 +8,7 @@ version = v"0.0.9"
 # Collection of sources required to build libsingular
 sources = [
     "https://github.com/Singular/Sources.git" =>
-    "ae2e290177fd5de77a3afac81e53b9da8977da9a",
-
+    "4c1fc06f2d81e12a8e75a5419444cb157fbe45e9",
 ]
 
 # Bash recipe for building across all platforms
@@ -43,13 +42,6 @@ cd Singular_build
     --with-ntl=$prefix \
     --without-python
 
-if [ $target = "x86_64-apple-darwin14" ]; then
-  wget ftp://jim.mathematik.uni-kl.de:/pub/Math/Singular/utils/singular-generated.tar.gz
-  wget ftp://jim.mathematik.uni-kl.de:/pub/Math/Singular/utils/singular-touch.sh
-  tar -xvf singular-generated.tar.gz
-  chmod 755 singular-touch.sh
-  ./singular-touch.sh
-fi
 make -j${nproc}
 make install
 exit


### PR DESCRIPTION
... thanks to the [recent cross compilation fixes in Singular master](https://github.com/Singular/Sources/commit/26b42ddcca6857a388490aa8398e5ed81434ab0e).

In principle we could now build for more target platforms, however
not all our dependencies (Flint...) provide for more platforms, so
we can't.

@hannes14 @wbhart how important is the NTL dependency? are there things it provides that are not (yet) covered by FLINT?